### PR TITLE
Fix the default sorting logic

### DIFF
--- a/krait/src/Console/CreateTableControllerCommand.php
+++ b/krait/src/Console/CreateTableControllerCommand.php
@@ -49,7 +49,7 @@ class CreateTableControllerCommand extends GeneratorCommand
         $controllerNamespace = $this->getNamespace($name);
         $controllerClass = str_replace($controllerNamespace.'\\', '', $name);
 
-        $tableNamespace = 'App\\Tables\\' . str_replace($controllerClass, '', $name);
+        $tableNamespace = 'App\\Tables\\'.str_replace($controllerClass, '', $name);
         $tableClass = str_replace('Controller', '', $controllerClass);
 
         $code = $stub;

--- a/krait/src/DTO/TableColumnDTO.php
+++ b/krait/src/DTO/TableColumnDTO.php
@@ -2,6 +2,8 @@
 
 namespace MtrDesign\Krait\DTO;
 
+use Illuminate\Support\Facades\Schema;
+
 /**
  * DTO Object for handling consistent column generation.
  */
@@ -63,6 +65,10 @@ readonly class TableColumnDTO
     public function sort(mixed $records, string $direction): mixed
     {
         if (empty($this->callbacks['sort'])) {
+            if (Schema::hasColumn($records->getModel()->getTable(), $this->name)) {
+                $records->orderBy($this->name, $direction);
+            }
+
             return $records;
         }
 

--- a/krait/src/Services/PreviewConfigService.php
+++ b/krait/src/Services/PreviewConfigService.php
@@ -3,8 +3,6 @@
 namespace MtrDesign\Krait\Services;
 
 use Exception;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Request;
 use MtrDesign\Krait\Models\KraitPreviewConfiguration;
@@ -42,10 +40,10 @@ class PreviewConfigService
      * @throws Exception
      */
     public function sort(
-        array|Collection|Builder|EloquentCollection $records,
+        mixed $records,
         KraitPreviewConfiguration $previewConfiguration,
         BaseTable $table,
-    ): array|Builder|EloquentCollection|Collection {
+    ): mixed {
         if (
             in_array(null, [$previewConfiguration->sort_column, $previewConfiguration->sort_direction]) ||
             ! $table->hasColumn($previewConfiguration->sort_column)

--- a/krait/src/Tables/BaseTable.php
+++ b/krait/src/Tables/BaseTable.php
@@ -191,7 +191,6 @@ abstract class BaseTable
      *
      * @param  Model|array  $resource  - The record.
      * @param  mixed|null  $placeholder  - The placeholder for empty values.
-     * @return array
      */
     public function processRecord(Model|array $resource, mixed $placeholder = null): array
     {
@@ -241,14 +240,6 @@ abstract class BaseTable
         $table->previewConfigService->sort($records, $previewConfiguration, $table);
 
         return new TableCollection($records, $table);
-    }
-
-    /**
-     * Returns the table name.
-     */
-    public static function getName(): string
-    {
-        return static::getFacade()->name();
     }
 
     /**


### PR DESCRIPTION
## Description
- default sorting logic fixed (now it uses the SQL column by default)

## Added PR Label?
- [x] 👍 yes

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
