### PR TITLE
Encode the table name in all krait routes

### DIFF
--- a/krait-ui/src/actions/hide-column.ts
+++ b/krait-ui/src/actions/hide-column.ts
@@ -34,7 +34,8 @@ export default class HideColumn extends BaseAction<
     }
 
     const url = Config.kraitUrl;
-    url.pathname = `${url.pathname}/preview-configurations/${this.tableName}/columns/visibility`;
+    const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
+    url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/visibility`;
 
     await ApiClient.fetch(
       url,

--- a/krait-ui/src/actions/resize-column.ts
+++ b/krait-ui/src/actions/resize-column.ts
@@ -54,7 +54,9 @@ export default class ResizeColumn extends BaseAction<
    */
   private async saveColumn(name: string, width: number): Promise<void> {
     const url = Config.kraitUrl;
-    url.pathname = `${url.pathname}/preview-configurations/${this.tableName}/columns/resize`;
+    const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
+    url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/resize`;
+    console.log(tablePath);
 
     await ApiClient.fetch(url, { name, width }, 'POST');
   }

--- a/krait-ui/src/actions/save-columns-order.ts
+++ b/krait-ui/src/actions/save-columns-order.ts
@@ -33,7 +33,8 @@ export default class SaveColumnsOrder extends BaseAction<
     });
 
     const url = Config.kraitUrl;
-    url.pathname = `${url.pathname}/preview-configurations/${this.tableName}/columns/reorder`;
+    const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
+    url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/reorder`;
 
     await ApiClient.fetch(
       url,

--- a/krait-ui/src/actions/save-records-per-page.ts
+++ b/krait-ui/src/actions/save-records-per-page.ts
@@ -25,7 +25,8 @@ export default class SaveRecordsPerPage extends BaseAction<
    */
   async process(_options: ISaveRecordsPerPageOptions) {
     const url = Config.kraitUrl;
-    url.pathname = `${url.pathname}/preview-configurations/${this.tableName}/columns/items-per-page`;
+    const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
+    url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/items-per-page`;
 
     console.log({
       items_per_page: this.context.pagination.itemsPerPage,

--- a/krait-ui/src/actions/sort-column.ts
+++ b/krait-ui/src/actions/sort-column.ts
@@ -31,7 +31,8 @@ export default class SortColumn extends BaseAction<
     this.context.sorting.direction = options.direction;
 
     const url = new URL(Config.kraitUrl);
-    url.pathname = `${url.pathname}/preview-configurations/${this.tableName}/columns/sort`;
+    const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
+    url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/sort`;
 
     await ApiClient.fetch(
       url,

--- a/krait/src/Http/Controllers/Api/ColumnsHideController.php
+++ b/krait/src/Http/Controllers/Api/ColumnsHideController.php
@@ -12,6 +12,7 @@ class ColumnsHideController extends Controller
      */
     public function __invoke(ColumnsHideRequest $request, string $table): JsonResponse
     {
+        $table = urldecode($table);
         $configuration = $this->getPreviewConfiguration($table);
         $configuration->update([
             'visible_columns' => $request->get('visible_columns'),

--- a/krait/src/Http/Controllers/Api/ColumnsReorderController.php
+++ b/krait/src/Http/Controllers/Api/ColumnsReorderController.php
@@ -12,6 +12,7 @@ class ColumnsReorderController extends Controller
      */
     public function __invoke(ColumnsReorderRequest $request, string $table): JsonResponse
     {
+        $table = urldecode($table);
         $configuration = $this->getPreviewConfiguration($table);
         $configuration->update([
             'columns_order' => $request->get('columns'),

--- a/krait/src/Http/Controllers/Api/ColumnsResizeController.php
+++ b/krait/src/Http/Controllers/Api/ColumnsResizeController.php
@@ -12,8 +12,8 @@ class ColumnsResizeController extends Controller
      */
     public function __invoke(ColumnsResizeRequest $request, string $table): JsonResponse
     {
+        $table = urldecode($table);
         $configuration = $this->getPreviewConfiguration($table);
-
         $config = $configuration->columns_width ?? [];
         $config[$request->get('name')] = $request->get('width');
         $configuration->update([

--- a/krait/src/Http/Controllers/Api/ColumnsSortController.php
+++ b/krait/src/Http/Controllers/Api/ColumnsSortController.php
@@ -12,6 +12,7 @@ class ColumnsSortController extends Controller
      */
     public function __invoke(ColumnsSortRequest $request, string $table): JsonResponse
     {
+        $table = urldecode($table);
         $configuration = $this->getPreviewConfiguration($table);
         $configuration->update([
             'sort_column' => $request->get('name'),

--- a/krait/src/Http/Controllers/Api/ItemsPerPageSaveController.php
+++ b/krait/src/Http/Controllers/Api/ItemsPerPageSaveController.php
@@ -12,6 +12,7 @@ class ItemsPerPageSaveController extends Controller
      */
     public function __invoke(ItemsPerPageSaveRequest $request, string $table): JsonResponse
     {
+        $table = urldecode($table);
         $configuration = $this->getPreviewConfiguration($table);
         $configuration->update([
             'items_per_page' => $request->get('items_per_page'),


### PR DESCRIPTION
## Description

- All table names are now encoded when passed to the internal Krait controllers

## Added PR Label?
- [x] 👍 yes

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
