### PR TITLE
Fix resize column many request issue

### DIFF
--- a/krait-ui/src/actions/resize-column.ts
+++ b/krait-ui/src/actions/resize-column.ts
@@ -1,13 +1,13 @@
-import {Config, ApiClient} from '~/framework';
+import { Config, ApiClient } from '~/framework';
 import BaseAction from './base-action';
 
 interface IResizeColumnOptions {
-    name: string;
-    width: number;
+  name: string;
+  width: number;
 }
 
 interface IResizeColumnResult {
-    success: boolean;
+  success: boolean;
 }
 
 /**
@@ -18,41 +18,43 @@ interface IResizeColumnResult {
  * @extends BaseAction
  */
 export default class ResizeColumn extends BaseAction<
-    IResizeColumnOptions,
-    IResizeColumnResult
+  IResizeColumnOptions,
+  IResizeColumnResult
 > {
-    /**
-     * Resized a table column and saves the configuration.
-     *
-     * @param {IResizeColumnOptions} options - The column options.
-     */
-    async process(options: IResizeColumnOptions) {
-        const column = this.context.columns.value.find((column) => column.name === options.name);
+  /**
+   * Resized a table column and saves the configuration.
+   *
+   * @param {IResizeColumnOptions} options - The column options.
+   */
+  async process(options: IResizeColumnOptions) {
+    const column = this.context.columns.value.find(
+      (column) => column.name === options.name,
+    );
 
-        if (!column) {
-            throw new Error(`Column ${options.name} not found.`);
-        }
-
-        await this.saveColumn(options.name, options.width);
-
-        return {
-            success: true,
-        };
+    if (!column) {
+      throw new Error(`Column ${options.name} not found.`);
     }
 
-    /**
-     * Saves the configuration to the back-end.
-     *
-     * @param {string} name - The column name.
-     * @param {number} width - The column width.
-     * @private
-     */
-    private async saveColumn(name: string, width: number): Promise<void> {
-        const url = Config.kraitUrl;
-        const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
-        url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/resize`;
-        console.log(tablePath);
+    await this.saveColumn(options.name, options.width);
 
-        await ApiClient.fetch(url, {name, width}, 'POST');
-    }
+    return {
+      success: true,
+    };
+  }
+
+  /**
+   * Saves the configuration to the back-end.
+   *
+   * @param {string} name - The column name.
+   * @param {number} width - The column width.
+   * @private
+   */
+  private async saveColumn(name: string, width: number): Promise<void> {
+    const url = Config.kraitUrl;
+    const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
+    url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/resize`;
+    console.log(tablePath);
+
+    await ApiClient.fetch(url, { name, width }, 'POST');
+  }
 }

--- a/krait-ui/src/actions/resize-column.ts
+++ b/krait-ui/src/actions/resize-column.ts
@@ -1,13 +1,13 @@
-import { Config, ApiClient } from '~/framework';
+import {Config, ApiClient} from '~/framework';
 import BaseAction from './base-action';
 
 interface IResizeColumnOptions {
-  name: string;
-  width: number;
+    name: string;
+    width: number;
 }
 
 interface IResizeColumnResult {
-  success: boolean;
+    success: boolean;
 }
 
 /**
@@ -18,46 +18,41 @@ interface IResizeColumnResult {
  * @extends BaseAction
  */
 export default class ResizeColumn extends BaseAction<
-  IResizeColumnOptions,
-  IResizeColumnResult
+    IResizeColumnOptions,
+    IResizeColumnResult
 > {
-  /**
-   * Resized a table column and saves the configuration.
-   *
-   * @param {IResizeColumnOptions} options - The column options.
-   */
-  async process(options: IResizeColumnOptions) {
-    const column = this.context.columns.value.find((column) => {
-      if (column.name === options.name) {
-        column.width = options.width;
-        return true;
-      }
-    });
+    /**
+     * Resized a table column and saves the configuration.
+     *
+     * @param {IResizeColumnOptions} options - The column options.
+     */
+    async process(options: IResizeColumnOptions) {
+        const column = this.context.columns.value.find((column) => column.name === options.name);
 
-    if (!column) {
-      throw new Error(`Column ${options.name} not found.`);
+        if (!column) {
+            throw new Error(`Column ${options.name} not found.`);
+        }
+
+        await this.saveColumn(options.name, options.width);
+
+        return {
+            success: true,
+        };
     }
 
-    await this.saveColumn(options.name, options.width);
+    /**
+     * Saves the configuration to the back-end.
+     *
+     * @param {string} name - The column name.
+     * @param {number} width - The column width.
+     * @private
+     */
+    private async saveColumn(name: string, width: number): Promise<void> {
+        const url = Config.kraitUrl;
+        const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
+        url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/resize`;
+        console.log(tablePath);
 
-    return {
-      success: true,
-    };
-  }
-
-  /**
-   * Saves the configuration to the back-end.
-   *
-   * @param {string} name - The column name.
-   * @param {number} width - The column width.
-   * @private
-   */
-  private async saveColumn(name: string, width: number): Promise<void> {
-    const url = Config.kraitUrl;
-    const tablePath = encodeURIComponent(encodeURIComponent(this.tableName));
-    url.pathname = `${url.pathname}/preview-configurations/${tablePath}/columns/resize`;
-    console.log(tablePath);
-
-    await ApiClient.fetch(url, { name, width }, 'POST');
-  }
+        await ApiClient.fetch(url, {name, width}, 'POST');
+    }
 }

--- a/krait-ui/src/components/dynamic-column/DynamicColumn.vue
+++ b/krait-ui/src/components/dynamic-column/DynamicColumn.vue
@@ -6,8 +6,8 @@ import {
   reactive,
   UnwrapNestedRefs,
 } from 'vue';
-import {ArrowDown, ArrowUp} from '@components/icons';
-import { debounce } from "~/framework/utils";
+import { ArrowDown, ArrowUp } from '@components/icons';
+import { debounce } from '~/framework/utils';
 
 interface IColumnState {
   xAxisCurrentCoords: any;
@@ -58,7 +58,7 @@ const debouncedEmitResize = debounce((e, name, colWidth) => {
 const mouseMove = (e: MouseEvent) => {
   state.xAxisNewCoords = state.xAxisCurrentCoords - e.clientX;
   state.colWidth = Math.floor(
-      state.rect.width - (state.xAxisCurrentCoords - e.clientX),
+    state.rect.width - (state.xAxisCurrentCoords - e.clientX),
   );
 
   debouncedEmitResize(e, props.name, state.colWidth);
@@ -85,36 +85,35 @@ const resizeStop = (): void => {
 
 onMounted(() => {
   state.colWidth = props.width;
-})
-
+});
 </script>
 
 <template>
   <th
-      :key="name"
-      scope="col"
-      :class="{ 'd-none': !isVisible, 'fixed-column': !isResizable }"
-      :style="{ width: `${state.colWidth >= 50 ? state.colWidth : 50}px` }"
+    :key="name"
+    scope="col"
+    :class="{ 'd-none': !isVisible, 'fixed-column': !isResizable }"
+    :style="{ width: `${state.colWidth >= 50 ? state.colWidth : 50}px` }"
   >
     <div class="d-inline-block text-truncate pe-1" style="width: 95%">
       {{ title }}
     </div>
     <span v-if="isSortable" class="sort" style="z-index: 1">
       <ArrowDown
-          :color="isActive ? '#0D6EFD' : '#adb5bd'"
-          v-if="isActive && sortDirection === 'desc'"
-          @click="() => emit('sort', name, 'asc')"
+        :color="isActive ? '#0D6EFD' : '#adb5bd'"
+        v-if="isActive && sortDirection === 'desc'"
+        @click="() => emit('sort', name, 'asc')"
       ></ArrowDown>
       <ArrowUp
-          :color="isActive ? '#0D6EFD' : '#adb5bd'"
-          @click="() => emit('sort', name, 'desc')"
-          v-else
+        :color="isActive ? '#0D6EFD' : '#adb5bd'"
+        @click="() => emit('sort', name, 'desc')"
+        v-else
       ></ArrowUp>
     </span>
     <div
-        v-if="isResizable"
-        class="col-resizer"
-        @mousedown="resizeCols($event)"
+      v-if="isResizable"
+      class="col-resizer"
+      @mousedown="resizeCols($event)"
     ></div>
   </th>
 </template>

--- a/krait-ui/src/framework/utils.ts
+++ b/krait-ui/src/framework/utils.ts
@@ -5,9 +5,51 @@
  * @param {string} path - The raw path.
  */
 export const sanityPath = (path: string) => {
-  if (path.endsWith('/')) {
-    path = path.slice(0, -1);
-  }
+    if (path.endsWith('/')) {
+        path = path.slice(0, -1);
+    }
 
-  return path;
+    return path;
 };
+
+/**
+ * Creates a debounced function that delays the invocation
+ * of the provided function until after the specified timeout
+ * has elapsed since the last time the debounced function was called.
+ *
+ * @param {Function} callback - The function to debounce.
+ * @param {number} [wait=300] - The number of milliseconds to delay.
+ * @param {boolean} [immediate=false] - The number of milliseconds to delay.
+ * @returns {Function} A new debounced function.
+ */
+export function debounce<T extends (...args: any[]) => void>(
+    callback: T,
+    wait: number,
+    immediate = false,
+) {
+    // This is a number in the browser and an object in Node.js,
+    // so we'll use the ReturnType utility to cover both cases.
+    let timeout: ReturnType<typeof setTimeout> | null;
+
+    return function <U>(this: U, ...args: Parameters<typeof callback>) {
+        const context = this;
+        const later = () => {
+            timeout = null;
+
+            if (!immediate) {
+                callback.apply(context, args);
+            }
+        };
+        const callNow = immediate && !timeout;
+
+        if (typeof timeout === "number") {
+            clearTimeout(timeout);
+        }
+
+        timeout = setTimeout(later, wait);
+
+        if (callNow) {
+            callback.apply(context, args);
+        }
+    };
+}

--- a/krait-ui/src/framework/utils.ts
+++ b/krait-ui/src/framework/utils.ts
@@ -5,11 +5,11 @@
  * @param {string} path - The raw path.
  */
 export const sanityPath = (path: string) => {
-    if (path.endsWith('/')) {
-        path = path.slice(0, -1);
-    }
+  if (path.endsWith('/')) {
+    path = path.slice(0, -1);
+  }
 
-    return path;
+  return path;
 };
 
 /**
@@ -23,33 +23,33 @@ export const sanityPath = (path: string) => {
  * @returns {Function} A new debounced function.
  */
 export function debounce<T extends (...args: any[]) => void>(
-    callback: T,
-    wait: number,
-    immediate = false,
+  callback: T,
+  wait: number,
+  immediate = false,
 ) {
-    // This is a number in the browser and an object in Node.js,
-    // so we'll use the ReturnType utility to cover both cases.
-    let timeout: ReturnType<typeof setTimeout> | null;
+  // This is a number in the browser and an object in Node.js,
+  // so we'll use the ReturnType utility to cover both cases.
+  let timeout: ReturnType<typeof setTimeout> | null;
 
-    return function <U>(this: U, ...args: Parameters<typeof callback>) {
-        const context = this;
-        const later = () => {
-            timeout = null;
+  return function <U>(this: U, ...args: Parameters<typeof callback>) {
+    const context = this;
+    const later = () => {
+      timeout = null;
 
-            if (!immediate) {
-                callback.apply(context, args);
-            }
-        };
-        const callNow = immediate && !timeout;
-
-        if (typeof timeout === "number") {
-            clearTimeout(timeout);
-        }
-
-        timeout = setTimeout(later, wait);
-
-        if (callNow) {
-            callback.apply(context, args);
-        }
+      if (!immediate) {
+        callback.apply(context, args);
+      }
     };
+    const callNow = immediate && !timeout;
+
+    if (typeof timeout === 'number') {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(later, wait);
+
+    if (callNow) {
+      callback.apply(context, args);
+    }
+  };
 }


### PR DESCRIPTION
## Description

When resizing the column, an excessive number of requests are sent to the server, leading to server overload and eventual rejection of the requests, causing the server to crash. #65 

## Added PR Label?
- [x] 👍 yes

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
