### PR TITLE
Add suffix to the methods so they don't conflict

### DIFF
--- a/krait/src/Tables/BaseTable.php
+++ b/krait/src/Tables/BaseTable.php
@@ -19,6 +19,8 @@ use MtrDesign\Krait\Services\PreviewConfigService;
  */
 abstract class BaseTable
 {
+    private const METHOD_SUFFIX = 'KraitAttribute';
+
     /**
      * The internal table columns.
      *
@@ -201,7 +203,7 @@ abstract class BaseTable
 
         $row = [];
         foreach ($this->getColumns() as $column) {
-            $columnMethod = sprintf('get%s', Str::ucfirst($column->name));
+            $columnMethod = sprintf('get%s%s', Str::ucfirst($column->name), self::METHOD_SUFFIX);
 
             if ($column->hasProcessingCallback()) {
                 $row[$column->name] = $column->process($resource) ?? $placeholder;


### PR DESCRIPTION
## Description
Added suffix to the get{ColumnName} methods. You can change it as I couldn't think of anything better. #50 

## Added PR Label?
- [x] 👍 yes

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
